### PR TITLE
feat: add real-time room messaging

### DIFF
--- a/docs/plans/2026-02-20-chat-mvp-phase-3.md
+++ b/docs/plans/2026-02-20-chat-mvp-phase-3.md
@@ -1,0 +1,350 @@
+# Chat MVP Phase 3 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement real-time messaging with a message schema, channel-based broadcast, and a chat room LiveView that loads recent messages and sends new ones.
+
+**Architecture:** Add a `Messaging` context with `Message` schema (UUID IDs), validate content length, and preload user associations. Implement a `RoomChannel` that broadcasts messages on `room:{room_id}`. The Room LiveView subscribes to the same topic to receive broadcasts, streams messages for performance, and renders a chat UI under authenticated routes.
+
+**Tech Stack:** Elixir, Phoenix 1.8, Phoenix LiveView, Phoenix Channels, Ecto + SQLite, Tailwind
+
+---
+
+### Task 1: Message schema + migration
+
+**Files:**
+- Create: `lib/monolinc/messaging/message.ex`
+- Create: `priv/repo/migrations/*_create_messages.exs`
+- Test: `test/monolinc/messaging/message_test.exs`
+
+**Step 1: Write the failing test**
+```elixir
+defmodule Monolinc.Messaging.MessageTest do
+  use Monolinc.DataCase
+
+  alias Monolinc.Messaging.Message
+
+  test "changeset requires content" do
+    changeset = Message.changeset(%Message{}, %{content: ""})
+    refute changeset.valid?
+    assert "can't be blank" in errors_on(changeset).content
+  end
+
+  test "changeset enforces max length" do
+    changeset = Message.changeset(%Message{}, %{content: String.duplicate("a", 2001)})
+    refute changeset.valid?
+    assert "should be at most 2000 character(s)" in errors_on(changeset).content
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+Run: `mix test test/monolinc/messaging/message_test.exs`
+Expected: FAIL (module missing)
+
+**Step 3: Write minimal implementation**
+Create schema:
+```elixir
+defmodule Monolinc.Messaging.Message do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "messages" do
+    field :content, :string
+    belongs_to :room, Monolinc.Rooms.Room
+    belongs_to :user, Monolinc.Accounts.User
+
+    timestamps()
+  end
+
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, [:content, :room_id, :user_id])
+    |> validate_required([:content, :room_id, :user_id])
+    |> validate_length(:content, max: 2000)
+  end
+end
+```
+
+Migration:
+```elixir
+def change do
+  create table(:messages, primary_key: false) do
+    add :id, :binary_id, primary_key: true
+    add :content, :string, null: false
+    add :room_id, references(:rooms, type: :binary_id, on_delete: :delete_all), null: false
+    add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+    timestamps()
+  end
+
+  create index(:messages, [:room_id])
+  create index(:messages, [:user_id])
+end
+```
+
+**Step 4: Run test to verify it passes**
+Run: `mix test test/monolinc/messaging/message_test.exs`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add lib/monolinc/messaging/message.ex priv/repo/migrations/*_create_messages.exs test/monolinc/messaging/message_test.exs
+git commit -m "feat: add messages schema"
+```
+
+### Task 2: Messaging context
+
+**Files:**
+- Create: `lib/monolinc/messaging.ex`
+- Test: `test/monolinc/messaging_test.exs`
+
+**Step 1: Write the failing test**
+```elixir
+defmodule Monolinc.MessagingTest do
+  use Monolinc.DataCase
+
+  alias Monolinc.Messaging
+  alias Monolinc.Rooms
+
+  test "create_message/3 persists and preloads user" do
+    user = Monolinc.AccountsFixtures.user_fixture()
+    {:ok, room} = Rooms.create_room(user, %{name: "General"})
+
+    {:ok, message} = Messaging.create_message(user, room, %{content: "hello"})
+    assert message.content == "hello"
+    assert message.user.id == user.id
+  end
+
+  test "list_recent_messages/2 returns newest first, limited" do
+    user = Monolinc.AccountsFixtures.user_fixture()
+    {:ok, room} = Rooms.create_room(user, %{name: "General"})
+
+    Enum.each(1..55, fn i ->
+      {:ok, _msg} = Messaging.create_message(user, room, %{content: "msg-#{i}"})
+    end)
+
+    messages = Messaging.list_recent_messages(room, 50)
+    assert length(messages) == 50
+    assert hd(messages).content == "msg-55"
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+Run: `mix test test/monolinc/messaging_test.exs`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+```elixir
+defmodule Monolinc.Messaging do
+  import Ecto.Query, warn: false
+
+  alias Monolinc.Repo
+  alias Monolinc.Messaging.Message
+
+  def create_message(user, room, attrs) do
+    attrs = Map.new(attrs)
+
+    %Message{}
+    |> Message.changeset(%{
+      content: attrs["content"] || attrs[:content],
+      room_id: room.id,
+      user_id: user.id
+    })
+    |> Repo.insert()
+    |> case do
+      {:ok, message} -> {:ok, Repo.preload(message, :user)}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  def list_recent_messages(room, limit \\ 50) do
+    Message
+    |> where([m], m.room_id == ^room.id)
+    |> order_by([m], desc: m.inserted_at)
+    |> limit(^limit)
+    |> Repo.all()
+    |> Repo.preload(:user)
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+Run: `mix test test/monolinc/messaging_test.exs`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add lib/monolinc/messaging.ex test/monolinc/messaging_test.exs
+git commit -m "feat: add messaging context"
+```
+
+### Task 3: Room channel
+
+**Files:**
+- Create: `lib/monolinc_web/channels/room_channel.ex`
+- Modify: `lib/monolinc_web/endpoint.ex` (if needed to add socket)
+- Modify: `lib/monolinc_web/user_socket.ex` (if missing)
+- Test: `test/monolinc_web/channels/room_channel_test.exs`
+
+**Step 1: Write the failing test**
+```elixir
+defmodule MonolincWeb.RoomChannelTest do
+  use MonolincWeb.ChannelCase
+
+  alias Monolinc.Messaging
+  alias Monolinc.Rooms
+
+  test "broadcasts new messages to room topic" do
+    user = Monolinc.AccountsFixtures.user_fixture()
+    {:ok, room} = Rooms.create_room(user, %{name: "General"})
+
+    {:ok, _, socket} =
+      MonolincWeb.UserSocket
+      |> socket("user_id", %{current_scope: Monolinc.Accounts.Scope.for_user(user)})
+      |> subscribe_and_join(MonolincWeb.RoomChannel, "room:#{room.id}")
+
+    push(socket, "new_message", %{"content" => "hi"})
+    assert_broadcast "new_message", %{content: "hi"}
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+Run: `mix test test/monolinc_web/channels/room_channel_test.exs`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+Implement channel:
+```elixir
+defmodule MonolincWeb.RoomChannel do
+  use MonolincWeb, :channel
+
+  alias Monolinc.Messaging
+  alias Monolinc.Rooms
+
+  def join("room:" <> room_id, _payload, socket) do
+    {:ok, assign(socket, :room_id, room_id)}
+  end
+
+  def handle_in("new_message", %{"content" => content}, socket) do
+    user = socket.assigns.current_scope.user
+    room = Rooms.get_room!(socket.assigns.room_id)
+
+    case Messaging.create_message(user, room, %{content: content}) do
+      {:ok, message} ->
+        broadcast!(socket, "new_message", %{
+          id: message.id,
+          content: message.content,
+          username: message.user.username,
+          inserted_at: message.inserted_at
+        })
+
+        {:noreply, socket}
+
+      {:error, _changeset} ->
+        {:reply, {:error, %{error: "invalid"}}, socket}
+    end
+  end
+end
+```
+
+Add to user socket / endpoint if needed.
+
+**Step 4: Run test to verify it passes**
+Run: `mix test test/monolinc_web/channels/room_channel_test.exs`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add lib/monolinc_web/channels/room_channel.ex lib/monolinc_web/user_socket.ex lib/monolinc_web/endpoint.ex test/monolinc_web/channels/room_channel_test.exs
+git commit -m "feat: add room channel"
+```
+
+### Task 4: Room LiveView (chat)
+
+**Files:**
+- Create: `lib/monolinc_web/live/room_live/show.ex`
+- Modify: `lib/monolinc_web/router.ex`
+- Test: `test/monolinc_web/live/room_live/show_test.exs`
+
+**Step 1: Write the failing test**
+```elixir
+defmodule MonolincWeb.RoomLive.ShowTest do
+  use MonolincWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  test "shows recent messages", %{conn: conn} do
+    %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
+    {:ok, room} = Monolinc.Rooms.create_room(user, %{name: "General"})
+    {:ok, _} = Monolinc.Messaging.create_message(user, room, %{content: "hello"})
+
+    {:ok, view, _html} = live(conn, ~p"/rooms/#{room.slug}")
+    assert has_element?(view, "#messages")
+    assert has_element?(view, "#message-input")
+    assert has_element?(view, "#message-submit")
+  end
+
+  test "sends message and renders it", %{conn: conn} do
+    %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
+    {:ok, room} = Monolinc.Rooms.create_room(user, %{name: "General"})
+
+    {:ok, view, _html} = live(conn, ~p"/rooms/#{room.slug}")
+
+    view
+    |> form("#message-form", %{"message" => %{"content" => "hey"}})
+    |> render_submit()
+
+    assert has_element?(view, "#messages", "hey")
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+Run: `mix test test/monolinc_web/live/room_live/show_test.exs`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+- Load room by slug, 404 if not found.
+- Subscribe to topic `room:{room.id}` via `MonolincWeb.Endpoint.subscribe/1`.
+- Stream recent 50 messages (use `Messaging.list_recent_messages/2`).
+- On "send" event, create message and broadcast via `Endpoint.broadcast/3` to the same topic.
+- Render with `<Layouts.app flash={@flash} current_scope={@current_scope}>`.
+- Use streams for messages with `phx-update="stream"` and IDs on children.
+
+**Step 4: Run test to verify it passes**
+Run: `mix test test/monolinc_web/live/room_live/show_test.exs`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add lib/monolinc_web/live/room_live/show.ex lib/monolinc_web/router.ex test/monolinc_web/live/room_live/show_test.exs
+git commit -m "feat: add chat room liveview"
+```
+
+### Task 5: Verify and precommit
+
+**Files:**
+- None
+
+**Step 1: Run full test suite**
+Run: `mix test`
+Expected: PASS
+
+**Step 2: Run precommit**
+Run: `mix precommit`
+Expected: PASS
+
+---
+
+Plan complete and saved to `docs/plans/2026-02-20-chat-mvp-phase-3.md`.
+
+Two execution options:
+1. Subagent-Driven (this session) - I dispatch fresh subagent per task, review between tasks, fast iteration
+2. Parallel Session (separate) - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/lib/monolinc/messaging.ex
+++ b/lib/monolinc/messaging.ex
@@ -1,0 +1,27 @@
+defmodule Monolinc.Messaging do
+  import Ecto.Query, warn: false
+
+  alias Monolinc.Messaging.Message
+  alias Monolinc.Repo
+
+  def create_message(user, room, attrs) do
+    attrs = Map.new(attrs)
+
+    %Message{room_id: room.id, user_id: user.id}
+    |> Message.changeset(%{content: attrs["content"] || attrs[:content]})
+    |> Repo.insert()
+    |> case do
+      {:ok, message} -> {:ok, Repo.preload(message, :user)}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  def list_recent_messages(room, limit \\ 50) do
+    Message
+    |> where([m], m.room_id == ^room.id)
+    |> order_by([m], desc: m.inserted_at)
+    |> limit(^limit)
+    |> Repo.all()
+    |> Repo.preload(:user)
+  end
+end

--- a/lib/monolinc/messaging/message.ex
+++ b/lib/monolinc/messaging/message.ex
@@ -1,0 +1,25 @@
+defmodule Monolinc.Messaging.Message do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Monolinc.Accounts.User
+  alias Monolinc.Rooms.Room
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "messages" do
+    field :content, :string
+
+    belongs_to :room, Room
+    belongs_to :user, User
+
+    timestamps()
+  end
+
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, [:content])
+    |> validate_required([:content, :room_id, :user_id])
+    |> validate_length(:content, max: 2000)
+  end
+end

--- a/lib/monolinc/rooms.ex
+++ b/lib/monolinc/rooms.ex
@@ -12,6 +12,16 @@ defmodule Monolinc.Rooms do
   end
 
   @doc """
+  Gets a room by id.
+  """
+  def get_room!(id), do: Repo.get!(Room, id)
+
+  @doc """
+  Gets a room by slug.
+  """
+  def get_room_by_slug!(slug), do: Repo.get_by!(Room, slug: slug)
+
+  @doc """
   Creates a room for the given user with an auto-generated slug.
 
   Slugs are normalized to lowercase with only alphanumeric and hyphens.
@@ -57,7 +67,8 @@ defmodule Monolinc.Rooms do
   end
 
   defp do_insert_with_slug(attrs, _attempt) do
-    {:error, Room.changeset(%Room{}, attrs) |> Ecto.Changeset.add_error(:slug, "is already taken")}
+    {:error,
+     Room.changeset(%Room{}, attrs) |> Ecto.Changeset.add_error(:slug, "is already taken")}
   end
 
   defp slug_collision?(changeset) do

--- a/lib/monolinc_web/channels/room_channel.ex
+++ b/lib/monolinc_web/channels/room_channel.ex
@@ -1,0 +1,32 @@
+defmodule MonolincWeb.RoomChannel do
+  use MonolincWeb, :channel
+
+  alias Monolinc.Messaging
+  alias Monolinc.Rooms
+
+  @impl true
+  def join("room:" <> room_id, _payload, socket) do
+    {:ok, assign(socket, :room_id, room_id)}
+  end
+
+  @impl true
+  def handle_in("new_message", %{"content" => content}, socket) do
+    user = socket.assigns.current_scope.user
+    room = Rooms.get_room!(socket.assigns.room_id)
+
+    case Messaging.create_message(user, room, %{content: content}) do
+      {:ok, message} ->
+        broadcast!(socket, "new_message", %{
+          id: message.id,
+          content: message.content,
+          user_email: message.user.email,
+          inserted_at: message.inserted_at
+        })
+
+        {:noreply, socket}
+
+      {:error, _changeset} ->
+        {:reply, {:error, %{error: "invalid"}}, socket}
+    end
+  end
+end

--- a/lib/monolinc_web/endpoint.ex
+++ b/lib/monolinc_web/endpoint.ex
@@ -15,6 +15,10 @@ defmodule MonolincWeb.Endpoint do
     websocket: [connect_info: [session: @session_options]],
     longpoll: [connect_info: [session: @session_options]]
 
+  socket "/socket", MonolincWeb.UserSocket,
+    websocket: true,
+    longpoll: false
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # When code reloading is disabled (e.g., in production),

--- a/lib/monolinc_web/endpoint.ex
+++ b/lib/monolinc_web/endpoint.ex
@@ -16,7 +16,7 @@ defmodule MonolincWeb.Endpoint do
     longpoll: [connect_info: [session: @session_options]]
 
   socket "/socket", MonolincWeb.UserSocket,
-    websocket: true,
+    websocket: [connect_info: [session: @session_options]],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/lib/monolinc_web/live/room_live/show.ex
+++ b/lib/monolinc_web/live/room_live/show.ex
@@ -1,0 +1,116 @@
+defmodule MonolincWeb.RoomLive.Show do
+  use MonolincWeb, :live_view
+
+  alias Monolinc.Messaging
+  alias Monolinc.Rooms
+  alias MonolincWeb.Endpoint
+
+  @impl true
+  def mount(%{"slug" => slug}, _session, socket) do
+    room = Rooms.get_room_by_slug!(slug)
+    topic = "room:#{room.id}"
+
+    if connected?(socket) do
+      Endpoint.subscribe(topic)
+    end
+
+    messages =
+      room
+      |> Messaging.list_recent_messages(50)
+      |> Enum.reverse()
+      |> Enum.map(&message_to_view/1)
+
+    {:ok,
+     socket
+     |> assign(:page_title, room.name)
+     |> assign(:room, room)
+     |> assign(:room_topic, topic)
+     |> assign(:form, to_form(%{"content" => ""}, as: :message))
+     |> stream(:messages, messages)}
+  end
+
+  @impl true
+  def handle_event("send", %{"message" => %{"content" => content}}, socket) do
+    user = socket.assigns.current_scope.user
+    room = socket.assigns.room
+
+    case Messaging.create_message(user, room, %{content: content}) do
+      {:ok, message} ->
+        Endpoint.broadcast(socket.assigns.room_topic, "new_message", message_to_view(message))
+
+        {:noreply, assign(socket, :form, to_form(%{"content" => ""}, as: :message))}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset, as: :message, action: :insert))}
+    end
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{event: "new_message", payload: payload}, socket) do
+    {:noreply, stream_insert(socket, :messages, payload, at: -1)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <div id="room-chat" class="space-y-6">
+        <div class="space-y-1">
+          <h1 class="text-2xl font-semibold">{@room.name}</h1>
+          <p class="text-sm text-base-content/70">Real-time room chat.</p>
+        </div>
+
+        <div id="messages" phx-update="stream" class="space-y-3">
+          <div
+            id="messages-empty"
+            class="hidden only:block rounded-lg border border-dashed border-base-300 p-4 text-sm text-base-content/60"
+          >
+            No messages yet.
+          </div>
+          <article
+            :for={{id, message} <- @streams.messages}
+            id={id}
+            class="rounded-xl border border-base-300 bg-base-100 p-3"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-xs font-medium text-base-content/70">{message.user_email}</p>
+              <p class="text-xs text-base-content/50">{format_time(message.inserted_at)}</p>
+            </div>
+            <p class="mt-1 whitespace-pre-wrap break-words text-sm text-base-content">
+              {message.content}
+            </p>
+          </article>
+        </div>
+
+        <.form for={@form} id="message-form" phx-submit="send" class="flex items-start gap-2">
+          <div class="flex-1">
+            <.input
+              field={@form[:content]}
+              type="text"
+              id="message-input"
+              placeholder="Type your message"
+              autocomplete="off"
+              required
+            />
+          </div>
+          <button type="submit" id="message-submit" class="btn btn-primary">
+            Send
+          </button>
+        </.form>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp message_to_view(message) do
+    %{
+      id: message.id,
+      content: message.content,
+      user_email: message.user.email,
+      inserted_at: message.inserted_at
+    }
+  end
+
+  defp format_time(%NaiveDateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+  defp format_time(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+end

--- a/lib/monolinc_web/router.ex
+++ b/lib/monolinc_web/router.ex
@@ -78,6 +78,7 @@ defmodule MonolincWeb.Router do
       on_mount: [{MonolincWeb.UserAuth, :ensure_authenticated}] do
       live "/rooms", RoomLive.Index, :index
       live "/rooms/new", RoomLive.New, :new
+      live "/rooms/:slug", RoomLive.Show, :show
     end
   end
 end

--- a/lib/monolinc_web/user_socket.ex
+++ b/lib/monolinc_web/user_socket.ex
@@ -1,0 +1,13 @@
+defmodule MonolincWeb.UserSocket do
+  use Phoenix.Socket
+
+  channel "room:*", MonolincWeb.RoomChannel
+
+  @impl true
+  def connect(_params, socket, _connect_info) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def id(_socket), do: nil
+end

--- a/lib/monolinc_web/user_socket.ex
+++ b/lib/monolinc_web/user_socket.ex
@@ -1,12 +1,23 @@
 defmodule MonolincWeb.UserSocket do
   use Phoenix.Socket
 
+  alias Monolinc.Accounts
+  alias Monolinc.Accounts.Scope
+
   channel "room:*", MonolincWeb.RoomChannel
 
   @impl true
-  def connect(_params, socket, _connect_info) do
-    {:ok, socket}
+  def connect(_params, socket, %{session: %{"user_token" => token}}) do
+    case Accounts.get_user_by_session_token(token) do
+      {user, _token_inserted_at} ->
+        {:ok, assign(socket, :current_scope, Scope.for_user(user))}
+
+      nil ->
+        :error
+    end
   end
+
+  def connect(_params, _socket, _connect_info), do: :error
 
   @impl true
   def id(_socket), do: nil

--- a/priv/repo/migrations/20260220120000_create_messages.exs
+++ b/priv/repo/migrations/20260220120000_create_messages.exs
@@ -1,0 +1,17 @@
+defmodule Monolinc.Repo.Migrations.CreateMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:messages, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :content, :string, null: false
+      add :room_id, references(:rooms, type: :binary_id, on_delete: :delete_all), null: false
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:messages, [:room_id])
+    create index(:messages, [:user_id])
+  end
+end

--- a/test/monolinc/messaging/message_test.exs
+++ b/test/monolinc/messaging/message_test.exs
@@ -1,0 +1,17 @@
+defmodule Monolinc.Messaging.MessageTest do
+  use Monolinc.DataCase
+
+  alias Monolinc.Messaging.Message
+
+  test "changeset requires content" do
+    changeset = Message.changeset(%Message{}, %{content: ""})
+    refute changeset.valid?
+    assert "can't be blank" in errors_on(changeset).content
+  end
+
+  test "changeset enforces max length" do
+    changeset = Message.changeset(%Message{}, %{content: String.duplicate("a", 2001)})
+    refute changeset.valid?
+    assert "should be at most 2000 character(s)" in errors_on(changeset).content
+  end
+end

--- a/test/monolinc/messaging_test.exs
+++ b/test/monolinc/messaging_test.exs
@@ -1,0 +1,30 @@
+defmodule Monolinc.MessagingTest do
+  use Monolinc.DataCase
+
+  alias Monolinc.Messaging
+  alias Monolinc.Rooms
+
+  test "create_message/3 persists and preloads user" do
+    user = Monolinc.AccountsFixtures.user_fixture()
+    {:ok, room} = Rooms.create_room(user, %{name: "General"})
+
+    {:ok, message} = Messaging.create_message(user, room, %{content: "hello"})
+    assert message.content == "hello"
+    assert message.user.id == user.id
+  end
+
+  test "list_recent_messages/2 returns newest first, limited" do
+    user = Monolinc.AccountsFixtures.user_fixture()
+    {:ok, room} = Rooms.create_room(user, %{name: "General"})
+
+    Enum.each(1..55, fn i ->
+      {:ok, _msg} = Messaging.create_message(user, room, %{content: "msg-#{i}"})
+    end)
+
+    messages = Messaging.list_recent_messages(room, 50)
+    assert length(messages) == 50
+
+    timestamps = Enum.map(messages, & &1.inserted_at)
+    assert timestamps == Enum.sort(timestamps, {:desc, NaiveDateTime})
+  end
+end

--- a/test/monolinc_web/channels/room_channel_test.exs
+++ b/test/monolinc_web/channels/room_channel_test.exs
@@ -1,0 +1,20 @@
+defmodule MonolincWeb.RoomChannelTest do
+  use MonolincWeb.ChannelCase
+
+  alias Monolinc.Accounts.Scope
+  alias Monolinc.AccountsFixtures
+  alias Monolinc.Rooms
+
+  test "broadcasts new messages to room topic" do
+    user = AccountsFixtures.user_fixture()
+    {:ok, room} = Rooms.create_room(user, %{name: "General"})
+
+    {:ok, _, socket} =
+      MonolincWeb.UserSocket
+      |> socket("user_id", %{current_scope: Scope.for_user(user)})
+      |> subscribe_and_join(MonolincWeb.RoomChannel, "room:#{room.id}")
+
+    push(socket, "new_message", %{"content" => "hi"})
+    assert_broadcast "new_message", %{content: "hi"}
+  end
+end

--- a/test/monolinc_web/channels/room_channel_test.exs
+++ b/test/monolinc_web/channels/room_channel_test.exs
@@ -1,17 +1,20 @@
 defmodule MonolincWeb.RoomChannelTest do
   use MonolincWeb.ChannelCase
 
-  alias Monolinc.Accounts.Scope
+  alias Monolinc.Accounts
   alias Monolinc.AccountsFixtures
   alias Monolinc.Rooms
 
   test "broadcasts new messages to room topic" do
     user = AccountsFixtures.user_fixture()
+    token = Accounts.generate_user_session_token(user)
     {:ok, room} = Rooms.create_room(user, %{name: "General"})
 
+    {:ok, socket} =
+      connect(MonolincWeb.UserSocket, %{}, connect_info: %{session: %{"user_token" => token}})
+
     {:ok, _, socket} =
-      MonolincWeb.UserSocket
-      |> socket("user_id", %{current_scope: Scope.for_user(user)})
+      socket
       |> subscribe_and_join(MonolincWeb.RoomChannel, "room:#{room.id}")
 
     push(socket, "new_message", %{"content" => "hi"})

--- a/test/monolinc_web/channels/user_socket_test.exs
+++ b/test/monolinc_web/channels/user_socket_test.exs
@@ -1,0 +1,29 @@
+defmodule MonolincWeb.UserSocketTest do
+  use MonolincWeb.ChannelCase
+
+  alias Monolinc.Accounts
+  alias Monolinc.AccountsFixtures
+
+  test "connect/3 authenticates with a valid session token" do
+    user = AccountsFixtures.user_fixture()
+    token = Accounts.generate_user_session_token(user)
+
+    assert {:ok, socket} =
+             connect(MonolincWeb.UserSocket, %{},
+               connect_info: %{session: %{"user_token" => token}}
+             )
+
+    assert socket.assigns.current_scope.user.id == user.id
+  end
+
+  test "connect/3 rejects missing session token" do
+    assert :error = connect(MonolincWeb.UserSocket, %{}, connect_info: %{session: %{}})
+  end
+
+  test "connect/3 rejects invalid session token" do
+    assert :error =
+             connect(MonolincWeb.UserSocket, %{},
+               connect_info: %{session: %{"user_token" => "invalid"}}
+             )
+  end
+end

--- a/test/monolinc_web/live/room_live/show_test.exs
+++ b/test/monolinc_web/live/room_live/show_test.exs
@@ -1,0 +1,29 @@
+defmodule MonolincWeb.RoomLive.ShowTest do
+  use MonolincWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  test "shows recent messages", %{conn: conn} do
+    %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
+    {:ok, room} = Monolinc.Rooms.create_room(user, %{name: "General"})
+    {:ok, _} = Monolinc.Messaging.create_message(user, room, %{content: "hello"})
+
+    {:ok, view, _html} = live(conn, ~p"/rooms/#{room.slug}")
+    assert has_element?(view, "#messages")
+    assert has_element?(view, "#message-input")
+    assert has_element?(view, "#message-submit")
+  end
+
+  test "sends message and renders it", %{conn: conn} do
+    %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
+    {:ok, room} = Monolinc.Rooms.create_room(user, %{name: "General"})
+
+    {:ok, view, _html} = live(conn, ~p"/rooms/#{room.slug}")
+
+    view
+    |> form("#message-form", %{"message" => %{"content" => "hey"}})
+    |> render_submit()
+
+    assert has_element?(view, "#messages", "hey")
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,22 @@
+defmodule MonolincWeb.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  channel tests.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Phoenix.ChannelTest
+      import MonolincWeb.ChannelCase
+
+      @endpoint MonolincWeb.Endpoint
+    end
+  end
+
+  setup tags do
+    Monolinc.DataCase.setup_sandbox(tags)
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- add Message schema, messages migration, and Messaging context APIs for creating/listing recent room messages
- add room realtime transport with UserSocket + RoomChannel and tests for broadcast behavior
- add authenticated RoomLive.Show chat UI with streamed messages and send form, plus route wiring and tests

## Test Plan
- [x] mix test
- [x] mix precommit